### PR TITLE
Add currency information to CSV transaction export

### DIFF
--- a/internal/csv/transactions.go
+++ b/internal/csv/transactions.go
@@ -11,7 +11,7 @@ import (
 func TransactionsString(transactions []viseca.Transaction) string {
 	var stringBuilder strings.Builder
 
-	stringBuilder.WriteString(`"TransactionID","Date","Merchant","Amount","PFMCategoryID","PFMCategoryName"`)
+	stringBuilder.WriteString(`"TransactionID","Date","Merchant","Amount","Currency","OriginalAmount","OriginalCurrency","PFMCategoryID","PFMCategoryName"`)
 	stringBuilder.WriteString("\n")
 
 	for _, transaction := range transactions {
@@ -29,6 +29,9 @@ func TransactionString(transaction viseca.Transaction) string {
 		transaction.Date,
 		prettiestMerchantName(transaction),
 		fmt.Sprintf("%.2f", transaction.Amount),
+		transaction.Currency,
+		fmt.Sprintf("%.2f", transaction.OriginalAmount),
+		transaction.OriginalCurrency,
 		transaction.PFMCategory.ID,
 		transaction.PFMCategory.Name,
 	}, `","`)

--- a/internal/csv/transactions_test.go
+++ b/internal/csv/transactions_test.go
@@ -42,7 +42,7 @@ var inputTransaction = viseca.Transaction{
 }
 
 func TestTransactionString(t *testing.T) {
-	expected := `"AUTH8c919db2-1c23-43f1-8862-61c31336d9b6","2021-10-20T17:05:44","ALDI","50.55","cv_groceries","Lebensmittel"`
+	expected := `"AUTH8c919db2-1c23-43f1-8862-61c31336d9b6","2021-10-20T17:05:44","ALDI","50.55","CHF","50.55","CHF","cv_groceries","Lebensmittel"`
 
 	assert.Equal(t, expected, csv.TransactionString(inputTransaction))
 }
@@ -50,10 +50,36 @@ func TestTransactionString(t *testing.T) {
 func TestTransactionsString(t *testing.T) {
 	inputTransactions := []viseca.Transaction{inputTransaction}
 	expected :=
-		`"TransactionID","Date","Merchant","Amount","PFMCategoryID","PFMCategoryName"` +
+		`"TransactionID","Date","Merchant","Amount","Currency","OriginalAmount","OriginalCurrency","PFMCategoryID","PFMCategoryName"` +
 			"\n" +
-			`"AUTH8c919db2-1c23-43f1-8862-61c31336d9b6","2021-10-20T17:05:44","ALDI","50.55","cv_groceries","Lebensmittel"` +
+			`"AUTH8c919db2-1c23-43f1-8862-61c31336d9b6","2021-10-20T17:05:44","ALDI","50.55","CHF","50.55","CHF","cv_groceries","Lebensmittel"` +
 			"\n"
 
 	assert.Equal(t, expected, csv.TransactionsString(inputTransactions))
+}
+
+func TestForeignCurrencyTransaction(t *testing.T) {
+	foreignTransaction := viseca.Transaction{
+		TransactionID:     "TRX2025051200004466612",
+		Date:              "2025-05-12T09:01:20+02:00",
+		MerchantName:      "CLAUDE.AI SUBSCRIPTION",
+		PrettyName:        "Claude.ai",
+		IsOnline:          true,
+		Amount:            17.15,
+		Currency:          "CHF",
+		OriginalAmount:    20.00,
+		OriginalCurrency:  "USD",
+		PFMCategory: viseca.PFMCategory{
+			ID:   "entertainment_and_leisure",
+			Name: "Entertainment & Leisure",
+		},
+		StateType: "booked",
+		Details:   "CLAUDE.AI SUBSCRIPTION",
+		Type:      "merchant",
+		IsBilled:  true,
+	}
+
+	expected := `"TRX2025051200004466612","2025-05-12T09:01:20+02:00","Claude.ai","17.15","CHF","20.00","USD","entertainment_and_leisure","Entertainment & Leisure"`
+
+	assert.Equal(t, expected, csv.TransactionString(foreignTransaction))
 }


### PR DESCRIPTION
# Add Currency Information to CSV Export

Tanks a lot for the helpful exporter, I've found it very useful.

## What this PR adds

This tiny PR extends the CSV export to also include currency information from transactions.

Feel free to include or decline this change based on your needs.