### PR TITLE
Switch to new reports endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This method processes the auth flow in the CLI and will trigger a 2FA request li
 
 1. Log in to [one.viseca.ch](https://one.viseca.ch)
 1. Go to "Transaktionen" on [one.viseca.ch](https://one.viseca.ch)
-1. Save the card ID from the path (between `/v1/card/` and `/transactions`)
+1. Save the card ID from the path (between `/v1/reports/cards/` and `/transactions`)
 
 1.  ```
     export VISECA_CLI_USERNAME=<email>
@@ -28,7 +28,7 @@ This method requires a valid session cookie obtained from an authenticated brows
 1. Open the developer tools of your browser and navigate to the network tab
 1. Go to "Transaktionen" on [one.viseca.ch](https://one.viseca.ch)
 1. Filter the URLs in the network tab of the developer tools for `transactions`
-1. Save the card ID from the path (between `/v1/card/` and `/transactions`) to an env file (see examples)
+1. Save the card ID from the path (between `/v1/reports/cards/` and `/transactions`) to an env file (see examples)
 1. Save the session cookie (`AL_SESS-S=AAAAAA...`) to an env file (see examples)
 
 1.  ```

--- a/pkg/viseca/card.go
+++ b/pkg/viseca/card.go
@@ -7,7 +7,7 @@ import (
 
 // ListTransactions returns the transactions for the given card and listOptions.
 func (client *Client) ListTransactions(ctx context.Context, card string, listOptions ListOptions) (*Transactions, error) {
-	path := fmt.Sprintf("card/%s/transactions", card)
+	path := fmt.Sprintf("reports/cards/%s/transactions", card)
 
 	request, err := client.NewRequest(path, "GET", nil)
 	if err != nil {

--- a/pkg/viseca/viseca.go
+++ b/pkg/viseca/viseca.go
@@ -38,16 +38,18 @@ const listOptionsDateFormat = "2006-01-02T15:04:05Z"
 
 // ListOptions holds the options for list actions.
 type ListOptions struct {
-	Offset    int
-	PageSize  int
-	StateType string
-	DateTo    time.Time
-	DateFrom  time.Time
+	OnlyCurrentCycle bool
+	Offset           int
+	PageSize         int
+	StateType        string
+	DateTo           time.Time
+	DateFrom         time.Time
 }
 
 // NewDefaultListOptions creates new default ListOptions.
 func NewDefaultListOptions() ListOptions {
 	listOptions := ListOptions{}
+	listOptions.OnlyCurrentCycle = false
 	listOptions.Offset = 0
 	listOptions.PageSize = 100
 	listOptions.StateType = "unknown"
@@ -57,6 +59,7 @@ func NewDefaultListOptions() ListOptions {
 
 func addListOptions(url *url.URL, listOptions ListOptions) {
 	query := url.Query()
+	query.Add("onlyCurrentCycle", strconv.FormatBool(listOptions.OnlyCurrentCycle))
 	query.Add("offset", strconv.Itoa(listOptions.Offset))
 	query.Add("pagesize", strconv.Itoa(listOptions.PageSize))
 	query.Add("statetype", listOptions.StateType)


### PR DESCRIPTION
The transaction overview in the frontend application is now using a new
endpoint `https://api.one.viseca.ch/v1/reports/cards/<card-id>/transactions`
instead of `https://api.one.viseca.ch/v1/card/<card-id>/transactions`.
